### PR TITLE
u-boot: Force to always run the compile task

### DIFF
--- a/layers/meta-balena-nanopi-r2c/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-balena-nanopi-r2c/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -26,6 +26,9 @@ do_configure_append() {
     merge_config.sh -m .config ${@" ".join(find_cfgs(d))}
 }
 
+# force to always compile so we make sure the bellow bootloader images get deployed
+do_compile[nostamp] = "1"
+
 do_compile_append() {
     # create bootloader image
     loaderimage --pack --uboot ${SPL_BINARY} ${DEPLOY_DIR_IMAGE}/u-boot.img 0x200000


### PR DESCRIPTION
We need to not use sstate because we have to be
sure we always have the boot images available
in the deploy directory.

Changelog-entry: Do not use sstate for compiling u-boot
Signed-off-by: Florin Sarbu <florin@balena.io>