### PR TITLE
nanopi-r2c.coffee: Delete deprecated supportsBlink field

### DIFF
--- a/nanopi-r2c.coffee
+++ b/nanopi-r2c.coffee
@@ -14,7 +14,6 @@ module.exports =
                 windows: 'https://www.balena.io/docs/learn/getting-started/nanopi-r2c/nodejs/'
                 osx: 'https://www.balena.io/docs/learn/getting-started/nanopi-r2c/nodejs/'
                 linux: 'https://www.balena.io/docs/learn/getting-started/nanopi-r2c/nodejs/'
-        supportsBlink: true
 
         options: [ networkOptions.group ]
 


### PR DESCRIPTION
This is now deprecated in favour of the hw contracts

Changelog-entry: Delete from .coffee file the deprecated supportsBlink field
Signed-off-by: Florin Sarbu <florin@balena.io>