### PR TITLE
linux-stable: Add support for Motorcomm YT8521

### DIFF
--- a/layers/meta-balena-nanopi-r2c/recipes-kernel/linux/files/0002-net-phy-add-driver-for-Motorcomm-yt8511-phy.patch
+++ b/layers/meta-balena-nanopi-r2c/recipes-kernel/linux/files/0002-net-phy-add-driver-for-Motorcomm-yt8511-phy.patch
@@ -1,0 +1,215 @@
+From 8f092f397f59eebec4d457dbc9888d67ff3889b2 Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@balena.io>
+Date: Mon, 31 Jan 2022 11:24:46 +0100
+Subject: [PATCH] net: phy: add driver for Motorcomm yt8511 phy
+
+Add a driver for the Motorcomm yt8511 phy that will be used in the
+production Pine64 rk3566-quartz64 development board.
+It supports gigabit transfer speeds, rgmii, and 125mhz clk output.
+
+Signed-off-by: Peter Geis <pgwipeout@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+
+This is a backport of the mainline commit 48e8c6f1612b3d2dccaea2285231def830cc5b8e
+
+Upstream-Status: Backport
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ MAINTAINERS                 |   6 ++
+ drivers/net/phy/Kconfig     |   6 ++
+ drivers/net/phy/Makefile    |   1 +
+ drivers/net/phy/motorcomm.c | 136 ++++++++++++++++++++++++++++++++++++
+ 4 files changed, 149 insertions(+)
+ create mode 100644 drivers/net/phy/motorcomm.c
+
+diff --git a/MAINTAINERS b/MAINTAINERS
+index 50659d76976b..3f83df481ac9 100644
+--- a/MAINTAINERS
++++ b/MAINTAINERS
+@@ -11404,6 +11404,12 @@ F:	Documentation/media/v4l-drivers/meye*
+ F:	drivers/media/pci/meye/
+ F:	include/uapi/linux/meye.h
+ 
++MOTORCOMM PHY DRIVER
++M:	Peter Geis <pgwipeout@gmail.com>
++L:	netdev@vger.kernel.org
++S:	Maintained
++F:	drivers/net/phy/motorcomm.c
++
+ MOXA SMARTIO/INDUSTIO/INTELLIO SERIAL CARD
+ M:	Jiri Slaby <jirislaby@gmail.com>
+ S:	Maintained
+diff --git a/drivers/net/phy/Kconfig b/drivers/net/phy/Kconfig
+index d140e3c93fe3..c5080fc975b7 100644
+--- a/drivers/net/phy/Kconfig
++++ b/drivers/net/phy/Kconfig
+@@ -465,6 +465,12 @@ config MICROSEMI_PHY
+ 	---help---
+ 	  Currently supports VSC8514, VSC8530, VSC8531, VSC8540 and VSC8541 PHYs
+ 
++config MOTORCOMM_PHY
++	tristate "Motorcomm PHYs"
++	help
++	  Enables support for Motorcomm network PHYs.
++	  Currently supports the YT8511 gigabit PHY.
++
+ config NATIONAL_PHY
+ 	tristate "National Semiconductor PHYs"
+ 	---help---
+diff --git a/drivers/net/phy/Makefile b/drivers/net/phy/Makefile
+index 2f5c7093a65b..8467d39f4d49 100644
+--- a/drivers/net/phy/Makefile
++++ b/drivers/net/phy/Makefile
+@@ -91,6 +91,7 @@ obj-$(CONFIG_MICREL_PHY)	+= micrel.o
+ obj-$(CONFIG_MICROCHIP_PHY)	+= microchip.o
+ obj-$(CONFIG_MICROCHIP_T1_PHY)	+= microchip_t1.o
+ obj-$(CONFIG_MICROSEMI_PHY)	+= mscc/
++obj-$(CONFIG_MOTORCOMM_PHY)	+= motorcomm.o
+ obj-$(CONFIG_NATIONAL_PHY)	+= national.o
+ obj-$(CONFIG_NXP_TJA11XX_PHY)	+= nxp-tja11xx.o
+ obj-$(CONFIG_QSEMI_PHY)		+= qsemi.o
+diff --git a/drivers/net/phy/motorcomm.c b/drivers/net/phy/motorcomm.c
+new file mode 100644
+index 000000000000..796b68f4b499
+--- /dev/null
++++ b/drivers/net/phy/motorcomm.c
+@@ -0,0 +1,136 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Driver for Motorcomm PHYs
++ *
++ * Author: Peter Geis <pgwipeout@gmail.com>
++ */
++
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include <linux/phy.h>
++
++#define PHY_ID_YT8511		0x0000010a
++
++#define YT8511_PAGE_SELECT	0x1e
++#define YT8511_PAGE		0x1f
++#define YT8511_EXT_CLK_GATE	0x0c
++#define YT8511_EXT_DELAY_DRIVE	0x0d
++#define YT8511_EXT_SLEEP_CTRL	0x27
++
++/* 2b00 25m from pll
++ * 2b01 25m from xtl *default*
++ * 2b10 62.m from pll
++ * 2b11 125m from pll
++ */
++#define YT8511_CLK_125M		(BIT(2) | BIT(1))
++#define YT8511_PLLON_SLP	BIT(14)
++
++/* RX Delay enabled = 1.8ns 1000T, 8ns 10/100T */
++#define YT8511_DELAY_RX		BIT(0)
++
++/* TX Gig-E Delay is bits 7:4, default 0x5
++ * TX Fast-E Delay is bits 15:12, default 0xf
++ * Delay = 150ps * N - 250ps
++ * On = 2000ps, off = 50ps
++ */
++#define YT8511_DELAY_GE_TX_EN	(0xf << 4)
++#define YT8511_DELAY_GE_TX_DIS	(0x2 << 4)
++#define YT8511_DELAY_FE_TX_EN	(0xf << 12)
++#define YT8511_DELAY_FE_TX_DIS	(0x2 << 12)
++
++static int yt8511_read_page(struct phy_device *phydev)
++{
++	return __phy_read(phydev, YT8511_PAGE_SELECT);
++};
++
++static int yt8511_write_page(struct phy_device *phydev, int page)
++{
++	return __phy_write(phydev, YT8511_PAGE_SELECT, page);
++};
++
++static int yt8511_config_init(struct phy_device *phydev)
++{
++	unsigned int ge, fe;
++	int ret, oldpage;
++
++	/* set clock mode to 125mhz */
++	oldpage = phy_select_page(phydev, YT8511_EXT_CLK_GATE);
++	if (oldpage < 0)
++		goto err_restore_page;
++
++	ret = __phy_modify(phydev, YT8511_PAGE, 0, YT8511_CLK_125M);
++	if (ret < 0)
++		goto err_restore_page;
++
++	/* set rgmii delay mode */
++	switch (phydev->interface) {
++	case PHY_INTERFACE_MODE_RGMII:
++		ge = YT8511_DELAY_GE_TX_DIS;
++		fe = YT8511_DELAY_FE_TX_DIS;
++		break;
++	case PHY_INTERFACE_MODE_RGMII_RXID:
++		ge = YT8511_DELAY_RX | YT8511_DELAY_GE_TX_DIS;
++		fe = YT8511_DELAY_FE_TX_DIS;
++		break;
++	case PHY_INTERFACE_MODE_RGMII_TXID:
++		ge = YT8511_DELAY_GE_TX_EN;
++		fe = YT8511_DELAY_FE_TX_EN;
++		break;
++	case PHY_INTERFACE_MODE_RGMII_ID:
++		ge = YT8511_DELAY_RX | YT8511_DELAY_GE_TX_EN;
++		fe = YT8511_DELAY_FE_TX_EN;
++		break;
++	default: /* leave everything alone in other modes */
++		break;
++	}
++
++	ret = __phy_modify(phydev, YT8511_PAGE, (YT8511_DELAY_RX | YT8511_DELAY_GE_TX_EN), ge);
++	if (ret < 0)
++		goto err_restore_page;
++
++	/* fast ethernet delay is in a separate page */
++	ret = __phy_write(phydev, YT8511_PAGE_SELECT, YT8511_EXT_DELAY_DRIVE);
++	if (ret < 0)
++		goto err_restore_page;
++
++	ret = __phy_modify(phydev, YT8511_PAGE, YT8511_DELAY_FE_TX_EN, fe);
++	if (ret < 0)
++		goto err_restore_page;
++
++	/* leave pll enabled in sleep */
++	ret = __phy_write(phydev, YT8511_PAGE_SELECT, YT8511_EXT_SLEEP_CTRL);
++	if (ret < 0)
++		goto err_restore_page;
++
++	ret = __phy_modify(phydev, YT8511_PAGE, 0, YT8511_PLLON_SLP);
++	if (ret < 0)
++		goto err_restore_page;
++
++err_restore_page:
++	return phy_restore_page(phydev, oldpage, ret);
++}
++
++static struct phy_driver motorcomm_phy_drvs[] = {
++	{
++		PHY_ID_MATCH_EXACT(PHY_ID_YT8511),
++		.name		= "YT8511 Gigabit Ethernet",
++		.config_init	= yt8511_config_init,
++		.suspend	= genphy_suspend,
++		.resume		= genphy_resume,
++		.read_page	= yt8511_read_page,
++		.write_page	= yt8511_write_page,
++	},
++};
++
++module_phy_driver(motorcomm_phy_drvs);
++
++MODULE_DESCRIPTION("Motorcomm PHY driver");
++MODULE_AUTHOR("Peter Geis");
++MODULE_LICENSE("GPL");
++
++static const struct mdio_device_id __maybe_unused motorcomm_tbl[] = {
++	{ PHY_ID_MATCH_EXACT(PHY_ID_YT8511) },
++	{ /* sentinal */ }
++};
++
++MODULE_DEVICE_TABLE(mdio, motorcomm_tbl);
+-- 
+2.17.1
+

--- a/layers/meta-balena-nanopi-r2c/recipes-kernel/linux/files/0003-net-phy-fix-yt8511-clang-uninitialized-variable-warning.patch
+++ b/layers/meta-balena-nanopi-r2c/recipes-kernel/linux/files/0003-net-phy-fix-yt8511-clang-uninitialized-variable-warning.patch
@@ -1,0 +1,37 @@
+From 546d6bad18c04926c4d0eba4222654a9a60ea830 Mon Sep 17 00:00:00 2001
+From: Peter Geis <pgwipeout@gmail.com>
+Date: Sat, 29 May 2021 07:05:55 -0400
+Subject: [PATCH] net: phy: fix yt8511 clang uninitialized variable warning
+
+clang doesn't preinitialize variables. If phy_select_page failed and
+returned an error, phy_restore_page would be called with `ret` being
+uninitialized.
+Even though phy_restore_page won't use `ret` in this scenario,
+initialize `ret` to silence the warning.
+
+Fixes: 48e8c6f1612b ("net: phy: add driver for Motorcomm yt8511 phy")
+Reported-by: kernel test robot <lkp@intel.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Peter Geis <pgwipeout@gmail.com>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+
+Upstream-Status: Backport
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ drivers/net/phy/motorcomm.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/phy/motorcomm.c b/drivers/net/phy/motorcomm.c
+index 796b68f4b4993..68cd19540c677 100644
+--- a/drivers/net/phy/motorcomm.c
++++ b/drivers/net/phy/motorcomm.c
+@@ -50,8 +50,8 @@ static int yt8511_write_page(struct phy_device *phydev, int page)
+ 
+ static int yt8511_config_init(struct phy_device *phydev)
+ {
++	int oldpage, ret = 0;
+ 	unsigned int ge, fe;
+-	int ret, oldpage;
+ 
+ 	/* set clock mode to 125mhz */
+ 	oldpage = phy_select_page(phydev, YT8511_EXT_CLK_GATE);

--- a/layers/meta-balena-nanopi-r2c/recipes-kernel/linux/files/0004-net-phy-abort-loading-yt8511-driver-in-unsupported-modes.patch
+++ b/layers/meta-balena-nanopi-r2c/recipes-kernel/linux/files/0004-net-phy-abort-loading-yt8511-driver-in-unsupported-modes.patch
@@ -1,0 +1,71 @@
+From 0cc8bddb5b0665283baba6d89684630663c0ccbd Mon Sep 17 00:00:00 2001
+From: Peter Geis <pgwipeout@gmail.com>
+Date: Sat, 29 May 2021 07:05:56 -0400
+Subject: [PATCH] net: phy: abort loading yt8511 driver in unsupported modes
+
+While investigating the clang `ge` uninitialized variable report, it was
+discovered the default switch would have unintended consequences. Due to
+the switch to __phy_modify, the driver would modify the ID values in the
+default scenario.
+
+Fix this by promoting the interface mode switch and aborting when the
+mode is not a supported RGMII mode.
+
+This prevents the `ge` and `fe` variables from ever being used
+uninitialized.
+
+Fixes: 48e8c6f1612b ("net: phy: add driver for Motorcomm yt8511 phy")
+Reported-by: kernel test robot <lkp@intel.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Peter Geis <pgwipeout@gmail.com>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+
+Upstream-Status: Backport
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ drivers/net/phy/motorcomm.c | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/net/phy/motorcomm.c b/drivers/net/phy/motorcomm.c
+index 68cd19540c677..7e6ac2c5e27ef 100644
+--- a/drivers/net/phy/motorcomm.c
++++ b/drivers/net/phy/motorcomm.c
+@@ -53,15 +53,10 @@ static int yt8511_config_init(struct phy_device *phydev)
+ 	int oldpage, ret = 0;
+ 	unsigned int ge, fe;
+ 
+-	/* set clock mode to 125mhz */
+ 	oldpage = phy_select_page(phydev, YT8511_EXT_CLK_GATE);
+ 	if (oldpage < 0)
+ 		goto err_restore_page;
+ 
+-	ret = __phy_modify(phydev, YT8511_PAGE, 0, YT8511_CLK_125M);
+-	if (ret < 0)
+-		goto err_restore_page;
+-
+ 	/* set rgmii delay mode */
+ 	switch (phydev->interface) {
+ 	case PHY_INTERFACE_MODE_RGMII:
+@@ -80,14 +75,20 @@ static int yt8511_config_init(struct phy_device *phydev)
+ 		ge = YT8511_DELAY_RX | YT8511_DELAY_GE_TX_EN;
+ 		fe = YT8511_DELAY_FE_TX_EN;
+ 		break;
+-	default: /* leave everything alone in other modes */
+-		break;
++	default: /* do not support other modes */
++		ret = -EOPNOTSUPP;
++		goto err_restore_page;
+ 	}
+ 
+ 	ret = __phy_modify(phydev, YT8511_PAGE, (YT8511_DELAY_RX | YT8511_DELAY_GE_TX_EN), ge);
+ 	if (ret < 0)
+ 		goto err_restore_page;
+ 
++	/* set clock mode to 125mhz */
++	ret = __phy_modify(phydev, YT8511_PAGE, 0, YT8511_CLK_125M);
++	if (ret < 0)
++		goto err_restore_page;
++
+ 	/* fast ethernet delay is in a separate page */
+ 	ret = __phy_write(phydev, YT8511_PAGE_SELECT, YT8511_EXT_DELAY_DRIVE);
+ 	if (ret < 0)

--- a/layers/meta-balena-nanopi-r2c/recipes-kernel/linux/files/0005-net-phy-motorcomm-Add-YT8521-support.patch
+++ b/layers/meta-balena-nanopi-r2c/recipes-kernel/linux/files/0005-net-phy-motorcomm-Add-YT8521-support.patch
@@ -1,0 +1,149 @@
+From bbbf6cd702ac6370c9fa44a9d9a09a7834dc823d Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@balena.io>
+Date: Mon, 31 Jan 2022 11:40:09 +0100
+Subject: [PATCH] net: phy: motorcomm: Add YT8521 support
+
+This adds basic support for the Motorcomm YT8521 Gigabit Ethernet PHY.
+
+Signed-off-by: Walker Chen <walker.chen@starfivetech.com>
+Signed-off-by: Emil Renner Berthing <kernel@esmil.dk>
+
+This is a backport of commit https://github.com/esmil/linux/commit/658542f784ab519945ff535fbf60096edc067a2f
+
+Upstream-Status: Backport
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ drivers/net/phy/Kconfig     |  2 +-
+ drivers/net/phy/motorcomm.c | 68 +++++++++++++++++++++++++++++++++++++
+ 2 files changed, 69 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/phy/Kconfig b/drivers/net/phy/Kconfig
+index c5080fc975b7..cb98eb33ae0d 100644
+--- a/drivers/net/phy/Kconfig
++++ b/drivers/net/phy/Kconfig
+@@ -469,7 +469,7 @@ config MOTORCOMM_PHY
+ 	tristate "Motorcomm PHYs"
+ 	help
+ 	  Enables support for Motorcomm network PHYs.
+-	  Currently supports the YT8511 gigabit PHY.
++	  Currently supports the YT8511 and YT8521 gigabit PHYs.
+ 
+ config NATIONAL_PHY
+ 	tristate "National Semiconductor PHYs"
+diff --git a/drivers/net/phy/motorcomm.c b/drivers/net/phy/motorcomm.c
+index 7e6ac2c5e27e..2815e3c68bf8 100644
+--- a/drivers/net/phy/motorcomm.c
++++ b/drivers/net/phy/motorcomm.c
+@@ -10,6 +10,7 @@
+ #include <linux/phy.h>
+ 
+ #define PHY_ID_YT8511		0x0000010a
++#define PHY_ID_YT8521		0x0000011a
+ 
+ #define YT8511_PAGE_SELECT	0x1e
+ #define YT8511_PAGE		0x1f
+@@ -17,6 +18,10 @@
+ #define YT8511_EXT_DELAY_DRIVE	0x0d
+ #define YT8511_EXT_SLEEP_CTRL	0x27
+ 
++#define YT8521_EXT_SMI_SDS_PHY		0xa000
++#define YT8521_EXT_CHIP_CONFIG		0xa001
++#define YT8521_EXT_RGMII_CONFIG1	0xa003
++
+ /* 2b00 25m from pll
+  * 2b01 25m from xtl *default*
+  * 2b10 62.m from pll
+@@ -38,6 +43,17 @@
+ #define YT8511_DELAY_FE_TX_EN	(0xf << 12)
+ #define YT8511_DELAY_FE_TX_DIS	(0x2 << 12)
+ 
++/* YT8521 SMI_SDS_PHY */
++#define YT8521_SMI_SDS_PHY_UTP	0
++#define YT8521_SMI_SDS_PHY_SDS	BIT(1)
++
++/* YT8521 Chip_Config */
++#define YT8521_SW_RST_N_MODE	BIT(15)
++#define YT8521_RXC_DLY_EN	BIT(8)
++
++/* YT8521 RGMII_Config1 */
++#define YT8521_TX_DELAY_SEL	GENMASK(3, 0)
++
+ static int yt8511_read_page(struct phy_device *phydev)
+ {
+ 	return __phy_read(phydev, YT8511_PAGE_SELECT);
+@@ -111,6 +127,47 @@ static int yt8511_config_init(struct phy_device *phydev)
+ 	return phy_restore_page(phydev, oldpage, ret);
+ }
+ 
++static int yt8521_soft_reset(struct phy_device *phydev)
++{
++	phy_modify_paged(phydev, YT8521_EXT_CHIP_CONFIG, YT8511_PAGE,
++			 YT8521_SW_RST_N_MODE, 0);
++
++	return genphy_soft_reset(phydev);
++}
++
++static int yt8521_config_init(struct phy_device *phydev)
++{
++	int oldpage, ret = 0;
++
++	oldpage = phy_select_page(phydev, YT8521_EXT_SMI_SDS_PHY);
++	if (oldpage < 0)
++		goto err_restore_page;
++
++	/* switch to UTP access */
++	ret = __phy_write(phydev, YT8511_PAGE, YT8521_SMI_SDS_PHY_UTP);
++	if (ret < 0)
++		goto err_restore_page;
++
++	/* set tx delay to 3 * 150ps */
++	ret = __phy_write(phydev, YT8511_PAGE_SELECT, YT8521_EXT_RGMII_CONFIG1);
++	if (ret < 0)
++		goto err_restore_page;
++	ret = __phy_modify(phydev, YT8511_PAGE, YT8521_TX_DELAY_SEL, 3);
++	if (ret < 0)
++		goto err_restore_page;
++
++	/* disable rx delay */
++	ret = __phy_write(phydev, YT8511_PAGE_SELECT, YT8521_EXT_CHIP_CONFIG);
++	if (ret < 0)
++		goto err_restore_page;
++	ret = __phy_modify(phydev, YT8511_PAGE, YT8521_RXC_DLY_EN, 0);
++	if (ret < 0)
++		goto err_restore_page;
++
++err_restore_page:
++	return phy_restore_page(phydev, oldpage, ret);
++}
++
+ static struct phy_driver motorcomm_phy_drvs[] = {
+ 	{
+ 		PHY_ID_MATCH_EXACT(PHY_ID_YT8511),
+@@ -121,6 +178,16 @@ static struct phy_driver motorcomm_phy_drvs[] = {
+ 		.read_page	= yt8511_read_page,
+ 		.write_page	= yt8511_write_page,
+ 	},
++	{
++		PHY_ID_MATCH_EXACT(PHY_ID_YT8521),
++		.name		= "YT8521 Gigabit Ethernet",
++		.soft_reset	= yt8521_soft_reset,
++		.config_init	= yt8521_config_init,
++		.suspend	= genphy_suspend,
++		.resume		= genphy_resume,
++		.read_page	= yt8511_read_page,
++		.write_page	= yt8511_write_page,
++	},
+ };
+ 
+ module_phy_driver(motorcomm_phy_drvs);
+@@ -131,6 +198,7 @@ MODULE_LICENSE("GPL");
+ 
+ static const struct mdio_device_id __maybe_unused motorcomm_tbl[] = {
+ 	{ PHY_ID_MATCH_EXACT(PHY_ID_YT8511) },
++	{ PHY_ID_MATCH_EXACT(PHY_ID_YT8521) },
+ 	{ /* sentinal */ }
+ };
+ 
+-- 
+2.17.1
+

--- a/layers/meta-balena-nanopi-r2c/recipes-kernel/linux/linux-stable_%.bbappend
+++ b/layers/meta-balena-nanopi-r2c/recipes-kernel/linux/linux-stable_%.bbappend
@@ -2,4 +2,16 @@ inherit kernel-balena
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://0001-Revert-random-fix-crng_ready-test.patch"
+SRC_URI += " \
+    file://0001-Revert-random-fix-crng_ready-test.patch \
+    file://0002-net-phy-add-driver-for-Motorcomm-yt8511-phy.patch \
+    file://0003-net-phy-fix-yt8511-clang-uninitialized-variable-warning.patch \
+    file://0004-net-phy-abort-loading-yt8511-driver-in-unsupported-modes.patch \
+    file://0005-net-phy-motorcomm-Add-YT8521-support.patch \
+"
+
+# enable driver for YT8521S ethernet transceiver present on the NanoPi R2C
+BALENA_CONFIGS_append = " motorcomm"
+BALENA_CONFIGS[motorcomm] = " \
+    CONFIG_MOTORCOMM_PHY=y \
+"


### PR DESCRIPTION
This is the second ethernet transceiver used on the NanoPi R2C

Changelog-entry: Add support for Motorcomm YT8521 on NanoPi R2C
Signed-off-by: Florin Sarbu <florin@balena.io>