### PR TITLE
nanopi-r2c: Switch to kernel 5.15.11

### DIFF
--- a/layers/meta-balena-nanopi-r2c/conf/machine/nanopi-r2c.conf
+++ b/layers/meta-balena-nanopi-r2c/conf/machine/nanopi-r2c.conf
@@ -3,3 +3,9 @@
 #@DESCRIPTION: Machine configuration for the FriendlyARM NanoPi R2C, based on the Rockchip RK3328 SoC
 
 require conf/machine/nanopi-r2s.conf
+
+PREFERRED_PROVIDER_virtual/kernel = "linux-rockchip"
+PREFERRED_VERSION_linux-rockchip = "5.15%"
+
+KBUILD_DEFCONFIG = "nanopi-r2_linux_defconfig"
+KERNEL_DEVICETREE = "rockchip/rk3328-nanopi-r2-rev06.dtb"

--- a/layers/meta-balena-nanopi-r2c/recipes-bsp/u-boot/files/balenaos_bootcommand.cfg
+++ b/layers/meta-balena-nanopi-r2c/recipes-bsp/u-boot/files/balenaos_bootcommand.cfg
@@ -1,1 +1,2 @@
 CONFIG_BOOTCOMMAND="setenv resin_kernel_load_addr ${kernel_addr_r}; run resin_set_kernel_root; run set_os_cmdline; run distro_bootcmd"
+CONFIG_DEFAULT_FDT_FILE="rockchip/rk3328-nanopi-r2-rev06.dtb"

--- a/layers/meta-balena-nanopi-r2c/recipes-kernel/linux/linux-rockchip_%.bbappend
+++ b/layers/meta-balena-nanopi-r2c/recipes-kernel/linux/linux-rockchip_%.bbappend
@@ -1,0 +1,1 @@
+inherit kernel-balena

--- a/layers/meta-balena-nanopi-r2c/recipes-kernel/linux/linux-rockchip_5.15.11.bb
+++ b/layers/meta-balena-nanopi-r2c/recipes-kernel/linux/linux-rockchip_5.15.11.bb
@@ -1,0 +1,21 @@
+SUMMARY = "NanoPi R2C kernel"
+DESCRIPTION = "FriendlyElec NanoPi R2C machine kernel"
+
+LINUX_VERSION = "5.15.11"
+
+SRC_URI = " \
+    git://github.com/friendlyarm/kernel-rockchip;protocol=https;branch=nanopi-r2-v5.15.y \
+"
+SRCREV = "82c7f50525e010fe00eef88fd9747d310a80a5e5"
+
+require recipes-kernel/linux/linux-yocto.inc
+
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+KCONFIG_MODE="--alldefconfig"
+
+COMPATIBLE_MACHINE = "(nanopi-r2c)"
+
+LIC_FILES_CHKSUM = "file://LICENSES/preferred/GPL-2.0;md5=e6a75371ba4d16749254a51215d13f97"


### PR DESCRIPTION
This is the kernel version supplied by the hw vendor
and it has both eth ports working.

Changelog-entry: Switch to kernel 5.15.11 supplied by the hardware vendor
Signed-off-by: Florin Sarbu <florin@balena.io>