### PR TITLE
repo.yml: Specify full path in upstream

### DIFF
--- a/repo.yml
+++ b/repo.yml
@@ -2,7 +2,7 @@
 type: 'yocto-based OS image'
 reviewers: 1
 upstream:
-  - repo: 'meta-balena'
+  - repo: 'layers/meta-balena'
     url: 'http://github.com/balena-os/meta-balena'
   - repo: 'balena-yocto-scripts'
     url: 'http://github.com/balena-os/balena-yocto-scripts'


### PR DESCRIPTION
This is required so that versionist can automatically include nested
changelogs from renovate PRs.

Changelog-entry: Specify full path in repo.yml upstreams
Signed-off-by: Florin Sarbu <florin@balena.io>