### PR TITLE
u-boot: Use correct dtb name for R2C or R2S

### DIFF
--- a/layers/meta-balena-nanopi-r2c/recipes-bsp/u-boot/files/balenaos_bootcommand.cfg
+++ b/layers/meta-balena-nanopi-r2c/recipes-bsp/u-boot/files/balenaos_bootcommand.cfg
@@ -1,2 +1,1 @@
 CONFIG_BOOTCOMMAND="setenv resin_kernel_load_addr ${kernel_addr_r}; run resin_set_kernel_root; run set_os_cmdline; run distro_bootcmd"
-CONFIG_DEFAULT_FDT_FILE="rockchip/rk3328-nanopi-r2-rev06.dtb"

--- a/layers/meta-balena-nanopi-r2c/recipes-bsp/u-boot/files/r2c.cfg
+++ b/layers/meta-balena-nanopi-r2c/recipes-bsp/u-boot/files/r2c.cfg
@@ -1,0 +1,1 @@
+CONFIG_DEFAULT_FDT_FILE="rockchip/rk3328-nanopi-r2-rev06.dtb"

--- a/layers/meta-balena-nanopi-r2c/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-balena-nanopi-r2c/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -16,6 +16,10 @@ SRC_URI_append = " \
     file://balenaos_bootcommand.cfg \
 "
 
+SRC_URI_append_nanopi-r2c = " \
+    file://r2c.cfg \
+"
+
 BALENA_BOOT_PART_nanopi-r2s = "4"
 BALENA_DEFAULT_ROOT_PART_nanopi-r2s = "5"
 


### PR DESCRIPTION
Changelog-entry: Use correct dtb name in u-boot for R2C or R2S
Signed-off-by: Florin Sarbu <florin@balena.io>